### PR TITLE
Add .vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.defaultInterpreterPath": "/srv/conda/envs/notebook/bin/python"
+}


### PR DESCRIPTION
This is needed to ensure the correct python kernal opens
when we use vscode to render notebooks